### PR TITLE
Update to work with the Foundry translation

### DIFF
--- a/system.json
+++ b/system.json
@@ -42,7 +42,7 @@
       "path": "lang/fr.json"
     },
     {
-      "lang": "pt-br",
+      "lang": "pt-BR",
       "name": "Português Brasileiro",
       "path": "lang/pt-br.json"
     }


### PR DESCRIPTION
Foundry VTT translation works with lang pt-BR value.
Changing pt-br to pt-BR to the translation of the system works with the translation of the character sheet.